### PR TITLE
Layouts

### DIFF
--- a/mappings/LaunchPad-Playback.json
+++ b/mappings/LaunchPad-Playback.json
@@ -1,0 +1,350 @@
+{
+"control": {
+	"104": "201",
+	"105": "202",
+	"106": "203",
+	"107": "204",
+	"108": "205",
+	"109": "206",
+	"110": "207",
+	"111": "208"
+},
+"note": {
+	"11": {
+		"exec": 101,
+		"permanentFeedback": 21
+    	},
+	"12": {
+		"exec": 102,
+		"permanentFeedback": 21
+    	},
+	"13": {
+		"exec": 103,
+		"permanentFeedback": 21
+    	},
+	"14": {
+		"exec": 104,
+		"permanentFeedback": 21
+    	},
+	"15": {
+		"exec": 105,
+		"permanentFeedback": 21
+    	},
+	"16": {
+		"exec": 106,
+		"permanentFeedback": 21
+    	},
+	"17": {
+		"exec": 107,
+		"permanentFeedback": 21
+    	},
+	"18": {
+		"exec": 108,
+		"permanentFeedback": 21
+    	},
+	"19": {
+		"quicKey": "Store",
+		"minValue": 100,
+		"permanentFeedback": 21
+        },
+	"21": {
+		"exec": 301,
+		"permanentFeedback": 45
+    	},
+	"22": {
+		"exec": 302,
+		"permanentFeedback": 45
+    	},
+	"23": {
+		"exec": 303,
+		"permanentFeedback": 45
+    	},
+	"24": {
+		"exec": 304,
+		"permanentFeedback": 45
+    	},
+	"25": {
+		"exec": 305,
+		"permanentFeedback": 45
+    	},
+	"26": {
+		"exec": 306,
+		"permanentFeedback": 45
+    	},
+	"27": {
+		"exec": 307,
+		"permanentFeedback": 45
+    	},
+	"28": {
+		"exec": 308,
+		"permanentFeedback": 45
+    	},
+	"29": {
+		"quicKey": "Clear",
+		"minValue": 100,
+		"permanentFeedback": 9
+        },
+	"31": {
+		"exec": 401,
+		"permanentFeedback": 5
+    	},
+	"32": {
+		"exec": 402,
+		"permanentFeedback": 5
+    	},
+	"33": {
+		"exec": 403,
+		"permanentFeedback": 5
+    	},
+	"34": {
+		"exec": 404,
+		"permanentFeedback": 5
+    	},
+	"35": {
+		"exec": 405,
+		"permanentFeedback": 5
+    	},
+	"36": {
+		"exec": 406,
+		"permanentFeedback": 5
+    	},
+	"37": {
+		"exec": 407,
+		"permanentFeedback": 5
+    	},
+	"38": {
+		"exec": 408,
+		"permanentFeedback": 5
+    	},
+	"39": {
+		"quicKey": "Off",
+		"minValue": 100,
+		"permanentFeedback": 5
+        },
+	"41": {
+		"cmd": "At Preset 2.1",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"42": {
+		"cmd": "At Preset 2.2",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"43": {
+		"cmd": "At Preset 2.3",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"44": {
+		"cmd": "At Preset 2.4",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"45": {
+		"cmd": "At Preset 2.5",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"46": {
+		"cmd": "At Preset 6.1",
+		"minValue": 100,
+		"permanentFeedback": 33
+    	},
+	"47": {
+		"cmd": "At Preset 6.3",
+		"minValue": 100,
+		"permanentFeedback": 33
+    	},
+	"48": {
+		"cmd": "At Preset 6.5",
+		"minValue": 100,
+		"permanentFeedback": 33
+    	},
+	"49": {
+		"quicKey": "Oops",
+		"minValue": 100,
+		"permanentFeedback": 9
+        },
+	"51": {
+		"cmd": "At Preset 4.9",
+		"minValue": 100,
+		"permanentFeedback": 41
+    	},
+	"52": {
+		"cmd": "At Preset 4.10",
+		"minValue": 100,
+		"permanentFeedback": 45
+    	},
+	"53": {
+		"cmd": "At Preset 4.11",
+		"minValue": 100,
+		"permanentFeedback": 49
+    	},
+	"54": {
+		"cmd": "At Preset 4.12",
+		"minValue": 100,
+		"permanentFeedback": 53
+    	},
+	"55": {
+		"cmd": "At Preset 4.13",
+		"minValue": 100,
+		"permanentFeedback": 57
+    	},
+	"56": {
+		"cmd": "At Preset 4.14",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"57": {
+		"cmd": "At Preset 4.15",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"58": {
+		"cmd": "At Preset 4.16",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"59": {
+		"quicKey": "Please",
+		"minValue": 100,
+		"permanentFeedback": 21
+        },
+	"61": {
+		"cmd": "At Preset 4.1",
+		"minValue": 100,
+		"permanentFeedback": 3
+    	},
+	"62": {
+		"cmd": "At Preset 4.2",
+		"minValue": 100,
+		"permanentFeedback": 5
+    	},
+	"63": {
+		"cmd": "At Preset 4.3",
+		"minValue": 100,
+		"permanentFeedback": 9
+    	},
+	"64": {
+		"cmd": "At Preset 4.4",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"65": {
+		"cmd": "At Preset 4.5",
+		"minValue": 100,
+		"permanentFeedback": 17
+    	},
+	"66": {
+		"cmd": "At Preset 4.6",
+		"minValue": 100,
+		"permanentFeedback": 21
+    	},
+	"67": {
+		"cmd": "At Preset 4.7",
+		"minValue": 100,
+		"permanentFeedback": 29
+    	},
+	"68": {
+		"cmd": "At Preset 4.8",
+		"minValue": 100,
+		"permanentFeedback": 37
+    	},
+	"69": {
+		"quicKey": "Esc",
+		"minValue": 100,
+		"permanentFeedback": 49
+        },
+	"71": {
+		"cmd": "At Preset 1.1",
+		"minValue": 100,
+		"permanentFeedback": 0
+    	},
+	"72": {
+		"cmd": "At Preset 1.4",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"73": {
+		"cmd": "At Preset 1.7",
+		"minValue": 100,
+		"permanentFeedback": 2
+    	},
+	"74": {
+		"cmd": "At Preset 1.10",
+		"minValue": 100,
+		"permanentFeedback": 2
+    	},
+	"75": {
+		"cmd": "At Preset 1.13",
+		"minValue": 100,
+		"permanentFeedback": 3
+    	},
+	"76": {
+		"cmd": "At Preset 1.20",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"77": {
+		"cmd": "At Preset 1.21",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"78": {
+		"cmd": "At Preset 1.22",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"79": {
+		"cmd": "EditRecipe Programmer",
+		"minValue": 100,
+		"permanentFeedback": 45
+        },
+	"81": {
+		"cmd": "SelectFixtures Group 7",
+		"minValue": 100,
+		"permanentFeedback": 21
+    	},
+	"82": {
+		"cmd": "SelectFixtures Group 8",
+		"minValue": 100,
+		"permanentFeedback": 25
+    	},
+	"83": {
+		"cmd": "SelectFixtures Group 9",
+		"minValue": 100,
+		"permanentFeedback": 17
+    	},
+	"84": {
+		"cmd": "SelectFixtures Group 5",
+		"minValue": 100,
+		"permanentFeedback": 49
+    	},
+	"85": {
+		"cmd": "SelectFixtures Group 6",
+		"minValue": 100,
+		"permanentFeedback": 53
+    	},
+	"86": {
+		"cmd": "SelectFixtures Group 11",
+		"minValue": 100,
+		"permanentFeedback": 45
+    	},
+	"87": {
+		"cmd": "SelectFixtures Group 12",
+		"minValue": 100,
+		"permanentFeedback": 41
+    	},
+	"88": {
+		"cmd": "SelectFixtures Group 13",
+		"minValue": 100,
+		"permanentFeedback": 5
+    	},
+	"89": {
+		"cmd": "SaveShow",
+		"minValue": 100,
+		"permanentFeedback": 21
+        }
+  }
+}

--- a/mappings/LaunchPad-TriFlats.json
+++ b/mappings/LaunchPad-TriFlats.json
@@ -1,0 +1,350 @@
+{
+"control": {
+	"104": "201",
+	"105": "202",
+	"106": "203",
+	"107": "204",
+	"108": "205",
+	"109": "206",
+	"110": "207",
+	"111": "208"
+},
+"note": {
+	"11": {
+		"exec": 101,
+		"permanentFeedback": 21
+    	},
+	"12": {
+		"exec": 102,
+		"permanentFeedback": 21
+    	},
+	"13": {
+		"exec": 103,
+		"permanentFeedback": 21
+    	},
+	"14": {
+		"exec": 104,
+		"permanentFeedback": 21
+    	},
+	"15": {
+		"exec": 105,
+		"permanentFeedback": 21
+    	},
+	"16": {
+		"exec": 106,
+		"permanentFeedback": 21
+    	},
+	"17": {
+		"exec": 107,
+		"permanentFeedback": 21
+    	},
+	"18": {
+		"exec": 108,
+		"permanentFeedback": 21
+    	},
+	"19": {
+		"quicKey": "Store",
+		"minValue": 100,
+		"permanentFeedback": 21
+        },
+	"21": {
+		"exec": 301,
+		"permanentFeedback": 45
+    	},
+	"22": {
+		"exec": 302,
+		"permanentFeedback": 45
+    	},
+	"23": {
+		"exec": 303,
+		"permanentFeedback": 45
+    	},
+	"24": {
+		"exec": 304,
+		"permanentFeedback": 45
+    	},
+	"25": {
+		"exec": 305,
+		"permanentFeedback": 45
+    	},
+	"26": {
+		"exec": 306,
+		"permanentFeedback": 45
+    	},
+	"27": {
+		"exec": 307,
+		"permanentFeedback": 45
+    	},
+	"28": {
+		"exec": 308,
+		"permanentFeedback": 45
+    	},
+	"29": {
+		"quicKey": "Clear",
+		"minValue": 100,
+		"permanentFeedback": 9
+        },
+	"31": {
+		"exec": 401,
+		"permanentFeedback": 5
+    	},
+	"32": {
+		"exec": 402,
+		"permanentFeedback": 5
+    	},
+	"33": {
+		"exec": 403,
+		"permanentFeedback": 5
+    	},
+	"34": {
+		"exec": 404,
+		"permanentFeedback": 5
+    	},
+	"35": {
+		"exec": 405,
+		"permanentFeedback": 5
+    	},
+	"36": {
+		"exec": 406,
+		"permanentFeedback": 5
+    	},
+	"37": {
+		"exec": 407,
+		"permanentFeedback": 5
+    	},
+	"38": {
+		"exec": 408,
+		"permanentFeedback": 5
+    	},
+	"39": {
+		"quicKey": "Off",
+		"minValue": 100,
+		"permanentFeedback": 5
+        },
+	"41": {
+		"cmd": "At Preset 2.1",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"42": {
+		"cmd": "At Preset 2.2",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"43": {
+		"cmd": "At Preset 2.3",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"44": {
+		"cmd": "At Preset 2.4",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"45": {
+		"cmd": "At Preset 2.5",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"46": {
+		"cmd": "At Preset 6.1",
+		"minValue": 100,
+		"permanentFeedback": 33
+    	},
+	"47": {
+		"cmd": "At Preset 6.3",
+		"minValue": 100,
+		"permanentFeedback": 33
+    	},
+	"48": {
+		"cmd": "At Preset 6.5",
+		"minValue": 100,
+		"permanentFeedback": 33
+    	},
+	"49": {
+		"quicKey": "Oops",
+		"minValue": 100,
+		"permanentFeedback": 9
+        },
+	"51": {
+		"cmd": "At Preset 4.9",
+		"minValue": 100,
+		"permanentFeedback": 41
+    	},
+	"52": {
+		"cmd": "At Preset 4.10",
+		"minValue": 100,
+		"permanentFeedback": 45
+    	},
+	"53": {
+		"cmd": "At Preset 4.11",
+		"minValue": 100,
+		"permanentFeedback": 49
+    	},
+	"54": {
+		"cmd": "At Preset 4.12",
+		"minValue": 100,
+		"permanentFeedback": 53
+    	},
+	"55": {
+		"cmd": "At Preset 4.13",
+		"minValue": 100,
+		"permanentFeedback": 57
+    	},
+	"56": {
+		"cmd": "At Preset 4.14",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"57": {
+		"cmd": "At Preset 4.15",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"58": {
+		"cmd": "At Preset 4.16",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"59": {
+		"quicKey": "Please",
+		"minValue": 100,
+		"permanentFeedback": 21
+        },
+	"61": {
+		"cmd": "At Preset 4.1",
+		"minValue": 100,
+		"permanentFeedback": 3
+    	},
+	"62": {
+		"cmd": "At Preset 4.2",
+		"minValue": 100,
+		"permanentFeedback": 5
+    	},
+	"63": {
+		"cmd": "At Preset 4.3",
+		"minValue": 100,
+		"permanentFeedback": 9
+    	},
+	"64": {
+		"cmd": "At Preset 4.4",
+		"minValue": 100,
+		"permanentFeedback": 13
+    	},
+	"65": {
+		"cmd": "At Preset 4.5",
+		"minValue": 100,
+		"permanentFeedback": 17
+    	},
+	"66": {
+		"cmd": "At Preset 4.6",
+		"minValue": 100,
+		"permanentFeedback": 21
+    	},
+	"67": {
+		"cmd": "At Preset 4.7",
+		"minValue": 100,
+		"permanentFeedback": 29
+    	},
+	"68": {
+		"cmd": "At Preset 4.8",
+		"minValue": 100,
+		"permanentFeedback": 37
+    	},
+	"69": {
+		"quicKey": "Esc",
+		"minValue": 100,
+		"permanentFeedback": 49
+        },
+	"71": {
+		"cmd": "At Preset 1.1",
+		"minValue": 100,
+		"permanentFeedback": 0
+    	},
+	"72": {
+		"cmd": "At Preset 1.4",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"73": {
+		"cmd": "At Preset 1.7",
+		"minValue": 100,
+		"permanentFeedback": 2
+    	},
+	"74": {
+		"cmd": "At Preset 1.10",
+		"minValue": 100,
+		"permanentFeedback": 2
+    	},
+	"75": {
+		"cmd": "At Preset 1.13",
+		"minValue": 100,
+		"permanentFeedback": 3
+    	},
+	"76": {
+		"cmd": "At Preset 1.20",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"77": {
+		"cmd": "At Preset 1.21",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"78": {
+		"cmd": "At Preset 1.22",
+		"minValue": 100,
+		"permanentFeedback": 11
+    	},
+	"79": {
+		"cmd": "EditRecipe Programmer",
+		"minValue": 100,
+		"permanentFeedback": 45
+        },
+	"81": {
+		"cmd": "Fixture 302",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"82": {
+		"cmd": "Fixture 303",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"83": {
+		"cmd": "Fixture 304",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"84": {
+		"cmd": "Fixture 305",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"85": {
+		"cmd": "Fixture 306",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"86": {
+		"cmd": "Fixture 307",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"87": {
+		"cmd": "Fixture 308",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"88": {
+		"cmd": "Fixture 309",
+		"minValue": 100,
+		"permanentFeedback": 1
+    	},
+	"89": {
+		"cmd": "SaveShow",
+		"minValue": 100,
+		"permanentFeedback": 21
+        }
+  }
+}

--- a/mappings/akaiApcMini2-Controller.json
+++ b/mappings/akaiApcMini2-Controller.json
@@ -1,0 +1,460 @@
+{
+  "control": {
+    "48": "201",
+    "49": "202",
+    "50": "203",
+    "51": "204",
+    "52": "205",
+    "53": "206",
+    "54": "207",
+    "55": "208",
+    "56": "209"
+  },
+  "note": {
+    "0": {
+      "exec": 101,
+      "permanentFeedback": 21,
+      "midiChannel": 7
+    },
+    "1": {
+      "exec": 102,
+      "permanentFeedback": 21,
+      "midiChannel": 7
+    },
+    "2": {
+      "exec": 103,
+      "permanentFeedback": 21,
+      "midiChannel": 7
+    },
+    "3": {
+      "exec": 104,
+      "permanentFeedback": 21,
+      "midiChannel": 7
+    },
+    "4": {
+      "exec": 105,
+      "permanentFeedback": 21,
+      "midiChannel": 7
+    },
+    "5": {
+      "exec": 106,
+      "permanentFeedback": 21,
+      "midiChannel": 7
+    },
+    "6": {
+      "exec": 107,
+      "permanentFeedback": 21,
+      "midiChannel": 7
+    },
+    "7": {
+      "exec": 108,
+      "permanentFeedback": 21,
+      "midiChannel": 7
+    },
+    "8": {
+      "exec": 301,
+	"permanentFeedback": 45,
+	"midiChannel": 7
+    },
+    "9": {
+      "exec": 302,
+	"permanentFeedback": 45,
+	"midiChannel": 7
+    },
+    "10": {
+      "exec": 303,
+	"permanentFeedback": 45,
+	"midiChannel": 7
+    },
+    "11": {
+      "exec": 304,
+	"permanentFeedback": 45,
+	"midiChannel": 7
+    },
+    "12": {
+      "exec": 305,
+	"permanentFeedback": 45,
+	"midiChannel": 7
+    },
+    "13": {
+      "exec": 306,
+	"permanentFeedback": 45,
+	"midiChannel": 7
+    },
+    "14": {
+      "exec": 307,
+	"permanentFeedback": 45,
+	"midiChannel": 7
+    },
+    "15": {
+      "exec": 308,
+	"permanentFeedback": 45,
+	"midiChannel": 7
+    },
+    "16": {
+      "exec": 401,
+	"permanentFeedback": 5,
+	"midiChannel": 7
+    },
+    "17": {
+      "exec": 402,
+	"permanentFeedback": 5,
+	"midiChannel": 7
+    },
+    "18": {
+      "exec": 403,
+	"permanentFeedback": 5,
+	"midiChannel": 7
+    },
+    "19": {
+      "exec": 404,
+	"permanentFeedback": 5,
+	"midiChannel": 7
+    },
+    "20": {
+      "exec": 405,
+	"permanentFeedback": 5,
+	"midiChannel": 7
+    },
+    "21": {
+      "exec": 406,
+	"permanentFeedback": 5,
+	"midiChannel": 7
+    },
+    "22": {
+      "exec": 407,
+	"permanentFeedback": 5,
+	"midiChannel": 7
+    },
+    "23": {
+      "exec": 408,
+	"permanentFeedback": 5,
+	"midiChannel": 7
+    },
+    "24": {
+      "cmd": "At Preset 6.1",
+      "minValue": 100,
+	"permanentFeedback": 33,
+	"midiChannel": 7
+    },
+    "25": {
+      "cmd": "At Preset 6.2",
+      "minValue": 100,
+	"permanentFeedback": 33,
+	"midiChannel": 7
+    },
+    "26": {
+      "cmd": "At Preset 6.3",
+      "minValue": 100,
+	"permanentFeedback": 33,
+	"midiChannel": 7
+    },
+    "27": {
+      "cmd": "At Preset 6.4",
+      "minValue": 100,
+	"permanentFeedback": 33,
+	"midiChannel": 7
+    },
+    "28": {
+      "cmd": "At Preset 6.5",
+      "minValue": 100,
+	"permanentFeedback": 33,
+	"midiChannel": 7
+    },
+    "29": {
+      "cmd": "At Preset 6.6",
+      "minValue": 100,
+	"permanentFeedback": 10,
+	"midiChannel": 7
+    },
+    "30": {
+      "cmd": "Go+ Sequence 31",
+      "minValue": 100,
+	"permanentFeedback": 53,
+	"midiChannel": 7
+    },
+    "31": {
+      "cmd": "Go+ Sequence 32",
+      "minValue": 100,
+	"permanentFeedback": 57,
+	"midiChannel": 7
+    },
+    "32": {
+      "cmd": "At Preset 2.1",
+      "minValue": 100,
+	"permanentFeedback": 13,
+	"midiChannel": 7
+    },
+    "33": {
+      "cmd": "At Preset 2.2",
+      "minValue": 100,
+	"permanentFeedback": 13,
+	"midiChannel": 7
+    },
+    "34": {
+      "cmd": "At Preset 2.3",
+      "minValue": 100,
+	"permanentFeedback": 13,
+	"midiChannel": 7
+    },
+    "35": {
+      "cmd": "At Preset 2.4",
+      "minValue": 100,
+	"permanentFeedback": 13,
+	"midiChannel": 7
+    },
+    "36": {
+      "cmd": "At Preset 2.5",
+      "minValue": 100,
+	"permanentFeedback": 13,
+	"midiChannel": 7
+    },
+    "37": {
+      "cmd": "At Preset 2.6",
+      "minValue": 100,
+	"permanentFeedback": 13,
+	"midiChannel": 7
+    },
+    "38": {
+      "cmd": "At Preset 2.7",
+      "minValue": 100,
+	"permanentFeedback": 10,
+	"midiChannel": 7
+    },
+    "39": {
+      "cmd": "At Preset 2.8",
+      "minValue": 100,
+	"permanentFeedback": 10,
+	"midiChannel": 7
+    },
+    "40": {
+      "cmd": "At Preset 1.1",
+      "minValue": 100,
+	"permanentFeedback": 3,
+	"midiChannel": 1
+    },
+    "41": {
+      "cmd": "At Preset 1.4",
+      "minValue": 100,
+	"permanentFeedback": 3,
+	"midiChannel": 2
+    },
+    "42": {
+      "cmd": "At Preset 1.5",
+      "minValue": 100,
+	"permanentFeedback": 3,
+	"midiChannel": 4
+    },
+    "43": {
+      "cmd": "At Preset 1.10",
+      "minValue": 100,
+	"permanentFeedback": 3,
+	"midiChannel": 5
+    },
+    "44": {
+      "cmd": "At Preset 1.13",
+      "minValue": 100,
+	"permanentFeedback": 3,
+	"midiChannel": 7
+    },
+    "45": {
+      "cmd": "At Preset 1.20",
+      "minValue": 100,
+	"permanentFeedback": 10,
+	"midiChannel": 7
+    },
+    "46": {
+      "cmd": "At Preset 1.21",
+      "minValue": 100,
+	"permanentFeedback": 10,
+	"midiChannel": 7
+    },
+    "47": {
+      "cmd": "At Preset 1.22",
+      "minValue": 100,
+	"permanentFeedback": 10,
+	"midiChannel": 7
+    },
+    "48": {
+      "cmd": "At Preset 4.9",
+      "minValue": 100,
+	"permanentFeedback": 41,
+	"midiChannel": 7
+    },
+    "49": {
+      "cmd": "At Preset 4.10",
+      "minValue": 100,
+	"permanentFeedback": 45,
+	"midiChannel": 7
+    },
+    "50": {
+      "cmd": "At Preset 4.11",
+      "minValue": 100,
+	"permanentFeedback": 49,
+	"midiChannel": 7
+    },
+    "51": {
+      "cmd": "At Preset 4.12",
+      "minValue": 100,
+	"permanentFeedback": 53,
+	"midiChannel": 7
+    },
+    "52": {
+      "cmd": "At Preset 4.13",
+      "minValue": 100,
+	"permanentFeedback": 57,
+	"midiChannel": 7
+    },
+    "53": {
+      "cmd": "At Preset 4.14",
+      "minValue": 100,
+	"permanentFeedback": 10,
+	"midiChannel": 7
+    },
+    "54": {
+      "cmd": "At Preset 4.15",
+      "minValue": 100,
+	"permanentFeedback": 10,
+	"midiChannel": 7
+    },
+    "55": {
+      "cmd": "At Preset 4.16",
+      "minValue": 100,
+	"permanentFeedback": 10,
+	"midiChannel": 7
+    },
+    "56": {
+      "cmd": "At Preset 4.1",
+      "minValue": 100,
+	"permanentFeedback": 3,
+	"midiChannel": 7
+    },
+    "57": {
+      "cmd": "At Preset 4.2",
+      "minValue": 100,
+	"permanentFeedback": 5,
+	"midiChannel": 7
+    },
+    "58": {
+      "cmd": "At Preset 4.3",
+      "minValue": 100,
+	"permanentFeedback": 9,
+	"midiChannel": 7
+    },
+    "59": {
+      "cmd": "At Preset 4.4",
+      "minValue": 100,
+	"permanentFeedback": 13,
+	"midiChannel": 7
+    },
+    "60": {
+      "cmd": "At Preset 4.5",
+      "minValue": 100,
+	"permanentFeedback": 17,
+	"midiChannel": 7
+    },
+    "61": {
+      "cmd": "At Preset 4.6",
+      "minValue": 100,
+	"permanentFeedback": 21,
+	"midiChannel": 7
+    },
+    "62": {
+      "cmd": "At Preset 4.7",
+      "minValue": 100,
+	"permanentFeedback": 29,
+	"midiChannel": 7
+    },
+    "63": {
+      "cmd": "At Preset 4.8",
+      "minValue": 100,
+	"permanentFeedback": 37,
+	"midiChannel": 7
+    },
+    "100": {
+      "cmd": "Group 7",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "101": {
+      "cmd": "Group 5",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "102": {
+      "cmd": "Group 6",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "103": {
+      "cmd": "Group 11",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "104": {
+      "cmd": "Group 12",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "105": {
+      "cmd": "Group 13",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "106": {
+      "cmd": "Previous Page",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "107": {
+      "cmd": "Next Page",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "112": {
+      "cmd": "SaveShow",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "113": {
+      "quicKey": "EditRecipe Programmer",
+      "minValue": 100 ,
+      "permanentFeedback": 127
+    },
+    "114": {
+      "quicKey": "Esc",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "115": {
+      "quicKey": "Please",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "116": {
+      "quicKey": "Oops",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "117": {
+      "quicKey": "Off",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "118": {
+      "quicKey": "Clear",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },    
+    "119": {
+      "quicKey": "Store",
+      "minValue": 100,
+      "permanentFeedback": 127
+    },
+    "122": {
+      "quicKey": "",
+      "minValue": 100,
+      "permanentFeedback": 127
+    }
+  }
+}

--- a/mappings/xTouch1.json
+++ b/mappings/xTouch1.json
@@ -15,7 +15,7 @@
     },
     "rltvControl": {
         "16": {
-            "exec": 401,
+            "exec": 301,
             "currValue": 0,
             "posFrom": 1,
             "posTo": 8,
@@ -26,7 +26,7 @@
             "returnTo": 43
         },
         "17": {
-            "exec": 402,
+            "exec": 302,
             "currValue": 0,
             "posFrom": 1,
             "posTo": 8,
@@ -37,7 +37,7 @@
             "returnTo": 43
         },
         "18": {
-            "exec": 403,
+            "exec": 303,
             "currValue": 0,
             "posFrom": 1,
             "posTo": 8,
@@ -48,7 +48,7 @@
             "returnTo": 43
         },
         "19": {
-            "exec": 404,
+            "exec": 304,
             "currValue": 0,
             "posFrom": 1,
             "posTo": 8,
@@ -59,7 +59,7 @@
             "returnTo": 43
         },
         "20": {
-            "exec": 405,
+            "exec": 305,
             "currValue": 0,
             "posFrom": 1,
             "posTo": 8,
@@ -70,7 +70,7 @@
             "returnTo": 43
         },
         "21": {
-            "exec": 406,
+            "exec": 306,
             "currValue": 0,
             "posFrom": 1,
             "posTo": 8,
@@ -81,7 +81,7 @@
             "returnTo": 43
         },
         "22": {
-            "exec": 407,
+            "exec": 307,
             "currValue": 0,
             "posFrom": 1,
             "posTo": 8,
@@ -92,7 +92,7 @@
             "returnTo": 43
         },
         "23": {
-            "exec": 408,
+            "exec": 308,
             "currValue": 0,
             "posFrom": 1,
             "posTo": 8,
@@ -138,52 +138,52 @@
             "exec": 408
         },
         "8": {
-            "exec": 301
-        },
-        "9": {
-            "exec": 302
-        },
-        "10": {
-            "exec": 303
-        },
-        "11": {
-            "exec": 304
-        },
-        "12": {
-            "exec": 305
-        },
-        "13": {
-            "exec": 306
-        },
-        "14": {
-            "exec": 307
-        },
-        "15": {
-            "exec": 308
-        },
-        "16": {
             "exec": 201
         },
-        "17": {
+        "9": {
             "exec": 202
         },
-        "18": {
+        "10": {
             "exec": 203
         },
-        "19": {
+        "11": {
             "exec": 204
         },
-        "20": {
+        "12": {
             "exec": 205
         },
-        "21": {
+        "13": {
             "exec": 206
         },
-        "22": {
+        "14": {
             "exec": 207
         },
-        "23": {
+        "15": {
             "exec": 208
+        },
+        "16": {
+            "exec": 301
+        },
+        "17": {
+            "exec": 302
+        },
+        "18": {
+            "exec": 303
+        },
+        "19": {
+            "exec": 304
+        },
+        "20": {
+            "exec": 305
+        },
+        "21": {
+            "exec": 306
+        },
+        "22": {
+            "exec": 307
+        },
+        "23": {
+            "exec": 308
         },
         "24": {
             "exec": 101
@@ -210,56 +210,68 @@
             "exec": 108
         },
         "32": {
-            "exec": 201
+            "exec": 101
         },
         "33": {
-            "exec": 202
+            "exec": 102
         },
         "34": {
-            "exec": 203
+            "exec": 103
         },
         "35": {
-            "exec": 204
+            "exec": 104
         },
         "36": {
-            "exec": 205
+            "exec": 105
         },
         "37": {
-            "exec": 206
+            "exec": 106
         },
         "38": {
-            "exec": 207
+            "exec": 107
         },
         "39": {
-            "exec": 208
+            "exec": 108
         },
         "40": {
-            "cmd": "HIGHLIGHT",
-            "minValue": 100
+            "cmd": "Call ViewButton 1.1",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "41": {
-            "cmd": "Preview",
-            "minValue": 100
+            "cmd": "Call ViewButton 1.4",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "42": {
-            "cmd": "SOLO",
-            "minValue": 100
+            "cmd": "Call ViewButton 1.2",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "43": {
-            "cmd": "BLIND",
-            "minValue": 100
+            "cmd": "Menu 'PlaybackControl'",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "44": {
-            "cmd": "Freeze",
-            "minValue": 100
+            "cmd": "Call ViewButton 1.3",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+	"45": {
+            "cmd": "Menu 'CommandControl'",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "46": {
             "cmd": "Previous Page",
-            "minValue": 100
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "47": {
             "cmd": "Next Page",
-            "minValue": 100
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "48": {
             "local": "encoderFine",
@@ -267,6 +279,14 @@
         },
         "49": {
             "local": "encoderRough",
+            "minValue": 100
+        },
+	"50": {
+            "cmd": "HIGHLIGHT",
+            "minValue": 100
+        },
+	"51": {
+            "cmd": "BLIND",
             "minValue": 100
         },
         "52": {
@@ -277,176 +297,236 @@
             "timecodePlayPause": true
         },
         "54": {
-            "exec": 191
-        },
-        "55": {
-            "exec": 192
-        },
-        "56": {
-            "exec": 193
-        },
-        "57": {
-            "exec": 194
-        },
-        "58": {
-            "exec": 195
-        },
-        "59": {
-            "exec": 196
-        },
-        "60": {
-            "exec": 197
-        },
-        "61": {
-            "exec": 198
-        },
-        "62": {
-            "exec": 291
-        },
-        "63": {
-            "exec": 292
-        },
-        "64": {
-            "exec": 293
-        },
-        "65": {
-            "exec": 294
-        },
-        "66": {
-            "exec": 295
-        },
-        "67": {
-            "exec": 296
-        },
-        "68": {
-            "exec": 297
-        },
-        "69": {
-            "exec": 298
-        },
-        "70": {
-            "quicKey": "Fixture",
-            "minValue": 100
-        },
-        "71": {
-            "quicKey": "Channel",
-            "minValue": 100
-        },
-        "72": {
-            "quicKey": "Assign",
-            "minValue": 100
-        },
-        "73": {
-            "quicKey": "Time",
-            "minValue": 100
-        },
-        "74": {
-            "quicKey": "Group",
-            "minValue": 100
-        },
-        "75": {
-            "quicKey": "Preset",
-            "minValue": 100
-        },
-        "76": {
-            "quicKey": "Sequence",
-            "minValue": 100
-        },
-        "77": {
-            "quicKey": "Update",
-            "minValue": 100
-        },
-        "78": {
-            "quicKey": "Store",
-            "minValue": 100
-        },
-        "79": {
-            "quicKey": "Move",
-            "minValue": 100
-        },
-        "80": {
-            "quicKey": "Cue",
-            "minValue": 100
-        },
-        "81": {
-            "quicKey": "Edit",
-            "minValue": 100
-        },
-        "82": {
-            "quicKey": "Delete",
-            "minValue": 100
-        },
-        "83": {
-            "quicKey": "Please",
-            "minValue": 100
-        },
-        "84": {
             "local": "attribute",
             "attribute": "dimmer"
         },
-        "85": {
+        "55": {
             "local": "attribute",
             "attribute": "pan"
         },
-        "86": {
+        "56": {
             "local": "attribute",
             "attribute": "tilt"
         },
-        "87": {
-            "local": "attribute",
-            "attribute": "ColorRGB_R"
-        },
-        "88": {
-            "local": "attribute",
-            "attribute": "ColorRGB_G"
-        },
-        "89": {
-            "local": "attribute",
-            "attribute": "ColorRGB_B"
-        },
-        "90": {
+        "57": {
             "local": "attribute",
             "attribute": "Zoom"
         },
-        "91": {
+        "58": {
+            "local": "attribute",
+            "attribute": "ColorRGB_R"
+        },
+        "59": {
+            "local": "attribute",
+            "attribute": "ColorRGB_G"
+        },
+        "60": {
+            "local": "attribute",
+            "attribute": "ColorRGB_B"
+        },
+	"61": {
+            "local": "attribute",
+            "attribute": "ColorRGB_W"
+        },
+        "62": {
+            "quicKey": "Fixture",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "63": {
+            "quicKey": "Channel",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "64": {
+	    "quicKey": "Group",
+            "minValue": 100 ,
+      	    "permanentFeedback": 127       
+	},
+        "65": {
+            "quicKey": "Preset",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "66": {
+            "quicKey": "Sequence",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "67": {
+            "quicKey": "Cue",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "68": {
+            "cmd": "Menu 'MenuSelector'",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "69": {
+            "cmd": "SaveShow",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "70": {
+            "quicKey": "Esc",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "71": {
+            "quicKey": "Select",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "72": {
+            "quicKey": "Freeze",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "73": {
+            "quicKey": "Solo",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "74": {
+            "quicKey": "Please",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "75": {
+            "quicKey": "Delete",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "76": {
+            "quicKey": "Oops",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "77": {
+            "quicKey": "Copy",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "78": {
+            "quicKey": "Move",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "79": {
+            "cmd": "EditRecipe Programmer",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "80": {
             "cmd": "Go-",
-            "minValue": 100
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "81": {
+            "cmd": "Go+",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "82": {
+            "quicKey": "Stomp",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "83": {
+            "quicKey": "Off",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "84": {
+            "quicKey": "Full",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "85": {
+            "quicKey": "Align",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "86": {
+            "quicKey": "Assign",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "87": {
+            "quicKey": "Edit",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "88": {
+            "quicKey": "Update",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "89": {
+            "quicKey": "Store",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "90": {
+            "quicKey": "Clear",
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "91": {
+            "cmd": "Top Timecode",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "92": {
-            "cmd": "Go+",
-            "minValue": 100
+            "cmd": "Go+ Timecode",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "93": {
-            "cmd": "Off",
-            "minValue": 100
+            "cmd": "Pause Timecode",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "94": {
-            "cmd": "Top",
-            "minValue": 100
+            "cmd": "Go+ Timecode",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "95": {
-            "cmd": "Clear",
-            "minValue": 100
+            "cmd": "Record Timecode",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "96": {
             "cmd": "UP",
-            "minValue": 100
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "97": {
             "cmd": "DOWN",
-            "minValue": 100
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "98": {
             "cmd": "PREVIOUS",
-            "minValue": 100
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "99": {
             "cmd": "NEXT",
-            "minValue": 100
+            "minValue": 100,
+      	    "permanentFeedback": 127
         },
         "100": {
             "cmd": "Set",
-            "minValue": 100
+            "minValue": 100,
+      	    "permanentFeedback": 127
+        },
+        "101": {
+            "cmd": "Store",
+            "minValue": 100,
+      	    "permanentFeedback": 127
         }
     },
     "display": {


### PR DESCRIPTION
Anbei sind die aktuellsten Versionen meiner Layouts. Ich nutze als Fixtures Tri Flats Par Profile, Cameo LED Spots, 2 Washer und 1 MovingHead.

- Behringer X-Touch: Buttons, Fader und Encoder beziehen sich jeweils auf eine Sequence, die auf alle 4 Bänke in grandMA3 gelegt wird, der Encoder dient für PreLoad der Cues. Die Command-Section ist in der Einteilung abgeändert, Befehle sind an den LED-Farben der Buttons orientiert.
- Akai Mini: Fader steuern die jeweiligen Groups an, diese können auch über die Buttons direkt über den Fadern ausgewählt werden. Die unteren drei Reihen setzen an den Exekutoren an, die oberen 5 Reihen greifen verschiedene Presets auf. Color-Presets orientieren sich an der grandMA3 Standard-Farbpalette.
- Launchpad Playback : sehr ähnlich zum Akai Mini, nur ohne die Fader. Erste Reihe ruft die Groups auf.
- Launchpad TriFlats: erste Reihe ruft Fixtures 302-309 auf.
- Launchpad Command-Section: ist noch in Arbeit und wird später nachgereicht

[APCmini - grandMA3 - v4.0.pdf](https://github.com/user-attachments/files/18466556/APCmini.-.grandMA3.-.v4.0.pdf)
[Launchpad - grandMA3 - v4.0.1 - Playback.pdf](https://github.com/user-attachments/files/18466557/Launchpad.-.grandMA3.-.v4.0.1.-.Playback.pdf)
[Launchpad - grandMA3 - v4.0.2 - Command-Section.pdf](https://github.com/user-attachments/files/18466558/Launchpad.-.grandMA3.-.v4.0.2.-.Command-Section.pdf)