### PR TITLE
Fix crash with encoder rough/fine

### DIFF
--- a/pam-OSC-Module.js
+++ b/pam-OSC-Module.js
@@ -222,11 +222,11 @@ module.exports = {
         if (config.local) {
           if (config.local == "encoderRough") {
             encoderRough = !encoderRough;
-            midiUtils.sendNoteResponse(routing, port, ctrl, encoderRough ? "On" : "Off", 1);
+            midiUtils.sendNoteResponse(routing, port, ctrl, encoderRough ? "On" : "Off", null, 1);
           }
           if (config.local == "encoderFine") {
             encoderFine = !encoderFine;
-            midiUtils.sendNoteResponse(routing, port, ctrl, encoderFine ? "On" : "Off", 1);
+            midiUtils.sendNoteResponse(routing, port, ctrl, encoderFine ? "On" : "Off", null, 1);
           }
 
           if (config.local == "attribute" && config.attribute) {


### PR DESCRIPTION
It looks like right now the encoder rough/fine buttons cause the js module to crash. This is due to `midiUtils.sendNoteReponse` having a different function definition than what's assumed in the existing code